### PR TITLE
✨ fix: correct YAML indentation in deployment template

### DIFF
--- a/helm-charts/doris-operator/Chart.yaml
+++ b/helm-charts/doris-operator/Chart.yaml
@@ -38,7 +38,7 @@ maintainers:
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.6.2-rc.1
+version: 1.6.2-rc.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/helm-charts/doris-operator/templates/deployment.yaml
+++ b/helm-charts/doris-operator/templates/deployment.yaml
@@ -120,7 +120,7 @@ spec:
             {{- toYaml .Values.dorisOperator.resources | nindent 12 }}
           {{- else -}}
             {{- include "operator.default.resource" . | indent 8 }}
-          {{- end -}}
+          {{- end }}
           volumeMounts:
             - mountPath:  /tmp/k8s-webhook-server/serving-certs
               name: cert


### PR DESCRIPTION
Adjusts the indentation in the `deployment.yaml` file to ensure proper  YAML formatting. Updates the chart version in `Chart.yaml` to  reflect the new release candidate version.