### PR TITLE
✨ chore: update chart version and add security contexts

### DIFF
--- a/helm-charts/doris/Chart.yaml
+++ b/helm-charts/doris/Chart.yaml
@@ -38,7 +38,7 @@ maintainers:
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.6.2-rc.1
+version: 1.6.2-rc.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/helm-charts/doris/templates/doriscluster.yaml
+++ b/helm-charts/doris/templates/doriscluster.yaml
@@ -89,6 +89,16 @@ spec:
     {{- end }}
     {{- end }}
 
+    {{- if .Values.feSpec.podSecurityContext }}
+    securityContext:
+      {{- toYaml .Values.feSpec.podSecurityContext | nindent 6 }}
+    {{- end }}
+
+    {{- if .Values.feSpec.containerSecurityContext }}
+    containerSecurityContext:
+      {{- toYaml .Values.feSpec.containerSecurityContext | nindent 6 }}
+    {{- end }}
+
     {{- if .Values.feSpec.resource }}
     {{- toYaml .Values.feSpec.resource | nindent 4 }}
     {{- else }}
@@ -186,6 +196,16 @@ spec:
         {{- template "doriscluster.beConfig.configMaps" . }}
     {{- end }}
     {{- end }}
+
+    {{- if .Values.beSpec.podSecurityContext }}
+    securityContext:
+      {{- toYaml .Values.beSpec.podSecurityContext | nindent 6 }}
+    {{- end }}
+
+    {{- if .Values.beSpec.containerSecurityContext }}
+    containerSecurityContext:
+      {{- toYaml .Values.beSpec.containerSecurityContext | nindent 6 }}
+    {{- end }}    
 
     {{- if .Values.beSpec.resource }}
     {{- toYaml .Values.beSpec.resource | nindent 4 }}
@@ -287,6 +307,16 @@ spec:
     {{- end }}
     {{- end }}
 
+    {{- if .Values.cnSpec.podSecurityContext }}
+    securityContext:
+      {{- toYaml .Values.cnSpec.podSecurityContext | nindent 6 }}
+    {{- end }}
+
+    {{- if .Values.cnSpec.containerSecurityContext }}
+    containerSecurityContext:
+      {{- toYaml .Values.cnSpec.containerSecurityContext | nindent 6 }}
+    {{- end }}
+
     {{- if .Values.cnSpec.resource }}
     {{- toYaml .Values.cnSpec.resource | nindent 4 }}
     {{- else }}
@@ -379,6 +409,16 @@ spec:
       configMaps:
         {{- template "doriscluster.brokerConfig.configMaps" . }}
     {{- end }}
+    {{- end }}
+
+    {{- if .Values.brokerSpec.podSecurityContext }}
+    securityContext:
+      {{- toYaml .Values.brokerSpec.podSecurityContext | nindent 6 }}
+    {{- end }}
+
+    {{- if .Values.brokerSpec.containerSecurityContext }}
+    containerSecurityContext:
+      {{- toYaml .Values.brokerSpec.containerSecurityContext | nindent 6 }}
     {{- end }}
 
     {{- if .Values.brokerSpec.resource }}

--- a/helm-charts/doris/values.yaml
+++ b/helm-charts/doris/values.yaml
@@ -147,6 +147,9 @@ feSpec:
     #     copy_file2: |
     #       text *** content
 
+  podSecurityContext: {}
+  containerSecurityContext: {}
+
   # If configured separately here, it will overwrite the total resources configuration default.
   # but the default configuration of other types will still take effect.
   resource: {}
@@ -316,6 +319,9 @@ beSpec:
     #       text *** content
     #     copy_file2: |
     #       text *** content
+
+  podSecurityContext: {}
+  containerSecurityContext: {}
 
   # If configured separately here, it will overwrite the total resources configuration default.
   # but the default configuration of other types will still take effect.
@@ -488,6 +494,9 @@ cnSpec:
     #     copy_file2: |
     #       text *** content
 
+  podSecurityContext: {}
+  containerSecurityContext: {}
+
   # If configured separately here, it will overwrite the total resources configuration default.
   # but the default configuration of other types will still take effect.
   resource: {}
@@ -652,6 +661,9 @@ brokerSpec:
     #     copy_file2: |
     #       text *** content
 
+  podSecurityContext: {}
+  containerSecurityContext: {}
+  
   # If configured separately here, it will overwrite the total resources configuration default.
   # but the default configuration of other types will still take effect.
   resource: {}


### PR DESCRIPTION
Bump the chart version to 1.6.2-rc.2 to reflect recent.   Introduce `podSecurityContext` and `containerSecurityContext`   for each component in the Helm chart to enhance security   configurations. This allows users to customize security   settings for their deployments.