### PR TITLE
✨ feat: add kickOffAffinityBe and enableWorkloadGroup

### DIFF
--- a/helm-charts/doris/Chart.yaml
+++ b/helm-charts/doris/Chart.yaml
@@ -38,7 +38,7 @@ maintainers:
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.6.2-rc.2
+version: 1.6.2-rc.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/helm-charts/doris/templates/doriscluster.yaml
+++ b/helm-charts/doris/templates/doriscluster.yaml
@@ -256,6 +256,9 @@ spec:
       {{- include "auth_proxy.alloydb" . | nindent 6 }}
     {{- end }}
     {{- end }}
+    {{- if .Values.beSpec.enableWorkloadGroup }}
+    enableWorkloadGroup: {{ .Values.beSpec.enableWorkloadGroup }}
+    {{- end }}
   {{- if .Values.dorisCluster.enabledCn }}
   cnSpec:
     replicas: {{ .Values.cnSpec.replicas }}
@@ -459,5 +462,8 @@ spec:
     {{- if .Values.brokerSpec.systemInitialization.command }}
       command: {{ .Values.brokerSpec.systemInitialization.command }}
     {{- end }}
+    {{- end }}
+    {{- if .Values.brokerSpec.kickOffAffinityBe }}
+    kickOffAffinityBe: {{ .Values.brokerSpec.kickOffAffinityBe }}
     {{- end }}
   {{- end }}

--- a/helm-charts/doris/values.yaml
+++ b/helm-charts/doris/values.yaml
@@ -427,6 +427,7 @@ beSpec:
     # - name: native-sidecar
     #   image: alpine:latest
     #   restartPolicy: Always
+  enableWorkloadGroup: ~
 
 cnSpec:
   replicas: 3
@@ -763,3 +764,4 @@ brokerSpec:
     # - name: native-sidecar
     #   image: alpine:latest
     #   restartPolicy: Always
+  kickOffAffinityBe: ~


### PR DESCRIPTION
Adds support for `kickOffAffinityBe` and `enableWorkloadGroup` in  the Doris Helm chart. These new values enhance the configuration  options for brokers and backend services, allowing for more  flexible deployment scenarios. Updates the chart version to  1.6.2-rc.3 to reflect these changes.